### PR TITLE
Feat/Notification-Searchbar: added functionality to the search bar in…

### DIFF
--- a/app/dashboard/notification/NotificationList.tsx
+++ b/app/dashboard/notification/NotificationList.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -5,7 +6,7 @@ import cancel from '../(assets)/cross.svg';
 import bing from '../(assets)/notification-bing.svg'
 import directbox from '../(assets)/directbox-notif.svg'
 
-const NotificationList = () => {
+const NotificationList = ({search}) => {
 
 const notifications = [
     {  
@@ -63,7 +64,7 @@ const notifications = [
 return (
     <div>
        {
-          notifications.map((item) => (
+          notifications.filter(item => item.heading.includes(search)).map((item) => (
             <div key={item.id} className="flex items-center justify-between shadow-sm border border-slate-300 rounded-lg bg-white mb-[2em]">
               <div className="flex items-center justify-between p-5">
                 <Image src={item.bing === 'bing' ? bing : directbox } alt="Notification Icon" width="20" height="20"  />

--- a/app/dashboard/notification/page.tsx
+++ b/app/dashboard/notification/page.tsx
@@ -1,16 +1,20 @@
+'use client';
 import { Search, Sidebar } from 'lucide-react';
-import React from 'react';
+import React, { useState } from 'react';
 import NotificationList from './NotificationList';
 
 type Props = {};
 
 const Notification = (props: Props) => {
 
+  const [search, setSearch] = useState('')
 
   return (
     <section className="w-full overflow-x-hidden py-[1em] px-[5em]">
 
       {/* Heading */}
+
+      {/* userClient(); */}
 
       <h1 className="text-[2.5rem] text-black font-bold  leading-10 p-2">Notifications</h1>
 
@@ -20,7 +24,7 @@ const Notification = (props: Props) => {
 
       <div className="flex items-center w-[92%] p-3 mx-[3em] my-[2em] bg-[#F8F8F8] rounded-lg">
         <Search />
-        <input className="bg-transparent text-[.875rem] w-[100%] px-3 py-1 outline-none" placeholder="Search for a notification..." />
+        <input className="bg-transparent text-[.875rem] w-[100%] px-3 py-1 outline-none" placeholder="Search for a notification..." onChange={e => setSearch(e.target.value)} />
       </div>
 
       {/* Line */}
@@ -31,7 +35,7 @@ const Notification = (props: Props) => {
 
       <div className="flex flex-col gap-8 py-[2em]">
 
-        <NotificationList />
+        <NotificationList search={search} />
 
       </div>
       


### PR DESCRIPTION
## Description
Added functionality to the search bar in the notification's page


## Screenshots (if appropriate - Postman, etc):

Before Search 


<img width="1440" alt="Screenshot 2023-11-15 at 21 41 15" src="https://github.com/Dream-Affairs/Dream-Affairs-Frontend/assets/113244998/e4351974-949a-462c-87b0-7ae6e53555b5">


After Search


<img width="1440" alt="Screenshot 2023-11-15 at 21 41 22" src="https://github.com/Dream-Affairs/Dream-Affairs-Frontend/assets/113244998/28f40e74-4f93-439b-8501-20130196ccf1">



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
